### PR TITLE
ucsi: More minor fixes and improvements

### DIFF
--- a/src/ucsi/lpm/get_connector_capability.rs
+++ b/src/ucsi/lpm/get_connector_capability.rs
@@ -407,13 +407,15 @@ impl From<ResponseData> for u32 {
 
 impl Encode for ResponseData {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        u32::from(*self).encode(encoder)
+        // TODO: fixup when we support different UCSI versions
+        (u32::from(*self) as u16).encode(encoder)
     }
 }
 
 impl<Context> Decode<Context> for ResponseData {
     fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
-        Ok(ResponseData::from(u32::decode(decoder)?))
+        // TODO: fixup when we support different UCSI versions
+        Ok(ResponseData::from(u16::decode(decoder)? as u32))
     }
 }
 

--- a/src/ucsi/mod.rs
+++ b/src/ucsi/mod.rs
@@ -152,7 +152,7 @@ impl<Context, T: PortId> Decode<Context> for Command<T> {
                 let command = ppm::Command::decode(&mut decoder)?;
                 Ok(Command::PpmCommand(command))
             }
-            CommandType::GetConnectorStatus => {
+            CommandType::GetConnectorStatus | CommandType::GetConnectorCapability => {
                 let command = lpm::Command::decode(&mut decoder)?;
                 Ok(Command::LpmCommand(command))
             }

--- a/src/ucsi/ppm/state_machine.rs
+++ b/src/ucsi/ppm/state_machine.rs
@@ -58,6 +58,8 @@ pub enum Input {
 pub enum Output {
     /// Notify OPM that command completed
     OpmNotifyCommandComplete,
+    /// Notify that ack was received
+    OpmNotifyAckComplete,
     /// Notify OPM of async event
     OpmNotifyAsyncEvent,
     /// Notify OPM of PPM reset
@@ -105,7 +107,7 @@ impl StateMachine {
 
         let (next_state, output) = match (self.state, input) {
             // Idle(false) transitions
-            (Idle(false), NotificationEnabled) => (Idle(true), Some(OpmNotifyCommandComplete)),
+            (Idle(false), NotificationEnabled) => (WaitForCommandCompleteAck, Some(OpmNotifyCommandComplete)),
             (Idle(false), BusyChanged) => (Busy(false), None),
             (Idle(false), CommandImmediate | CommandAsync) => (Idle(false), None),
 
@@ -126,7 +128,7 @@ impl StateMachine {
             }
 
             // WaitForCommandCompleteAck transitions
-            (WaitForCommandCompleteAck, CommandCompleteAck) => (Idle(true), None),
+            (WaitForCommandCompleteAck, CommandCompleteAck) => (Idle(true), Some(OpmNotifyAckComplete)),
 
             // WaitForAsyncEventAck transitions
             (WaitForAsyncEventAck, AsyncEventAck) => (Idle(true), None),


### PR DESCRIPTION
* `NotificationEnabled` PPM state now tranisitions to `WaitForCommandCompleteAck` correctly
* Add `OpmNotifyAckComplete` PPM output since ACK_CC_CI has its own completion flag
* Add `GET_CONNECTOR_CAPABILITY` to top-level decoder implementation