### PR TITLE
ucsi/lpm: Add iterator over GET_PDOS content

### DIFF
--- a/src/pdo/mod.rs
+++ b/src/pdo/mod.rs
@@ -33,6 +33,9 @@ pub const MW500_UNIT: u32 = 500;
 /// 1000 mW unit
 pub const MW1000_UNIT: u32 = 1000;
 
+/// Length of a PDO in bytes
+pub const PDO_LEN: usize = 4;
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum PdoKind {

--- a/src/ucsi/lpm/get_pdos.rs
+++ b/src/ucsi/lpm/get_pdos.rs
@@ -125,12 +125,21 @@ impl Args {
     }
 
     pub fn num_pdos(&self) -> u8 {
-        self.0.num_pdos()
+        // +1 as per UCSI spec
+        self.0.num_pdos() + 1
     }
 
-    pub fn set_num_pdos(&mut self, num_pdos: u8) -> &mut Self {
-        self.0.set_num_pdos(num_pdos);
-        self
+    /// Sets the number of PDOs to retrieve, must be in range 1..=MAX_PDOS
+    ///
+    /// Returns `None` if the value is out of range
+    pub fn set_num_pdos(&mut self, num_pdos: u8) -> Option<&mut Self> {
+        if num_pdos == 0 || num_pdos > MAX_PDOS as u8 {
+            return None;
+        }
+
+        // -1 as per UCSI spec
+        self.0.set_num_pdos(num_pdos - 1);
+        Some(self)
     }
 
     pub fn role(&self) -> PowerRole {
@@ -196,7 +205,25 @@ impl<Context> Decode<Context> for Args {
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ResponseData {
-    pub raw: [u32; MAX_PDOS],
+    raw: [u32; MAX_PDOS],
+}
+
+impl ResponseData {
+    pub fn iter(&self) -> impl Iterator<Item = u32> + '_ {
+        self.raw.iter().copied().take_while(|&pdo| pdo != 0)
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut u32> + '_ {
+        self.raw.iter_mut().take_while(|pdo| **pdo != 0)
+    }
+
+    pub fn len(&self) -> usize {
+        self.iter().count()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 impl Encode for ResponseData {
@@ -242,7 +269,7 @@ mod test {
     #[test]
     fn test_decode_args() {
         // Partner, connector 3, 1 PDO, source, maximum capabilities, offset 4
-        let encoded: [u8; 6] = [0x83, 0x04, 0x15, 0x00, 0x00, 0x00];
+        let encoded: [u8; 6] = [0x83, 0x04, 0x14, 0x00, 0x00, 0x00];
         let (decoded, size): (Args, usize) = decode_from_slice(&encoded, standard().with_fixed_int_encoding()).unwrap();
         assert_eq!(size, 6);
 
@@ -251,6 +278,7 @@ mod test {
             .set_partner(true)
             .set_pdo_offset(4)
             .set_num_pdos(1)
+            .unwrap()
             .set_role(PowerRole::Source)
             .set_source_capability_type(SourceCapabilityType::Maximum);
         assert_eq!(decoded, expected);


### PR DESCRIPTION
* Also fix PDO count
* Add PDO length constant

Breaking due to making `raw` private, iterators can be used to access contents now.