### PR TITLE
embedded-usb-pd: Audit panics

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -150,9 +150,10 @@ jobs:
       - name: cargo test
         run: cargo hack --feature-powerset --exclude-features defmt test --all-targets --locked
         # After ensuring tests pass, finally ensure the test code itself contains no clippy warnings
+        # Cap lints to avoid complaints about possible panics in our tests
       - name: cargo clippy
         run: |
-          cargo clippy --locked --tests
+          cargo clippy --locked --tests -- --cap-lints allow
 
   msrv:
     # check that we can build using the minimal rust version that is specified by this crate

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,17 @@ aquamarine = "0.6.0"
 [features]
 default = []
 defmt = ["dep:defmt"]
+
+[lints.clippy]
+correctness = "deny"
+expect_used = "deny"
+indexing_slicing = "deny"
+panic = "deny"
+panic_in_result_fn = "deny"
+perf = "deny"
+suspicious = "deny"
+style = "deny"
+todo = "deny"
+unimplemented = "deny"
+unreachable = "deny"
+unwrap_used = "deny"

--- a/src/pdo/mod.rs
+++ b/src/pdo/mod.rs
@@ -54,12 +54,15 @@ impl From<u32> for PdoKind {
 
 impl From<u8> for PdoKind {
     fn from(value: u8) -> Self {
+        // NOTE: If this mask changes, the panic safety comment below must be reevaluated
         const PDO_KIND_MASK: u8 = 0x3;
         match value & PDO_KIND_MASK {
             0x0 => PdoKind::Fixed,
             0x1 => PdoKind::Battery,
             0x2 => PdoKind::Variable,
             0x3 => PdoKind::Augmented,
+            // Panic safety: This will never panic if the mask above does not change
+            #[allow(clippy::unreachable)]
             _ => unreachable!(),
         }
     }

--- a/src/pdo/rdo.rs
+++ b/src/pdo/rdo.rs
@@ -22,17 +22,19 @@ pub enum Rdo {
 
 impl Rdo {
     /// Create a new RDO from the raw data and the corresponding PDO
-    pub fn for_pdo(rdo: u32, pdo: impl Common) -> Self {
-        match pdo.kind() {
+    ///
+    /// Returns `None` if `pdo` does not contain an APDO kind
+    pub fn for_pdo(rdo: u32, pdo: impl Common) -> Option<Self> {
+        Some(match pdo.kind() {
             PdoKind::Fixed => Rdo::Fixed(FixedVarRaw(rdo).into()),
             PdoKind::Variable => Rdo::Variable(FixedVarRaw(rdo).into()),
             PdoKind::Battery => Rdo::Battery(BatteryRaw(rdo).into()),
-            PdoKind::Augmented => match pdo.apdo_kind().unwrap() {
+            PdoKind::Augmented => match pdo.apdo_kind()? {
                 ApdoKind::SprPps => Rdo::Pps(PpsRaw(rdo).into()),
                 ApdoKind::EprAvs => Rdo::Pps(PpsRaw(rdo).into()),
                 ApdoKind::SprAvs => Rdo::Avs(AvsRaw(rdo).into()),
             },
-        }
+        })
     }
 }
 
@@ -375,7 +377,8 @@ mod tests {
                 voltage_mv: 0,
                 operational_current_ma: 0,
             }),
-        );
+        )
+        .unwrap();
         let expected = Rdo::Fixed(FixedVarData {
             object_position: 3,
             capability_mismatch: true,
@@ -401,7 +404,8 @@ mod tests {
                 min_voltage_mv: 0,
                 operational_current_ma: 0,
             }),
-        );
+        )
+        .unwrap();
         let expected = Rdo::Variable(FixedVarData {
             object_position: 3,
             capability_mismatch: true,
@@ -427,7 +431,8 @@ mod tests {
                 min_voltage_mv: 0,
                 operational_power_mw: 0,
             }),
-        );
+        )
+        .unwrap();
         let expected = Rdo::Battery(BatteryData {
             object_position: 3,
             capability_mismatch: true,
@@ -453,7 +458,8 @@ mod tests {
                 min_voltage_mv: 0,
                 max_current_ma: 0,
             })),
-        );
+        )
+        .unwrap();
         let expected = Rdo::Pps(PpsData {
             object_position: 3,
             capability_mismatch: true,
@@ -478,7 +484,8 @@ mod tests {
                 max_current_15v_ma: 0,
                 max_current_20v_ma: 0,
             })),
-        );
+        )
+        .unwrap();
         let expected = Rdo::Avs(AvsData {
             object_position: 3,
             capability_mismatch: true,

--- a/src/pdo/sink.rs
+++ b/src/pdo/sink.rs
@@ -152,12 +152,15 @@ pub enum FrsRequiredCurrent {
 
 impl From<u8> for FrsRequiredCurrent {
     fn from(value: u8) -> Self {
+        // NOTE: If this mask changes, the panic safety comment below must be reevaluated
         const FRS_REQUIRED_CURRENT_MASK: u8 = 0x3;
         match value & FRS_REQUIRED_CURRENT_MASK {
             0 => FrsRequiredCurrent::None,
             1 => FrsRequiredCurrent::Default,
             2 => FrsRequiredCurrent::Current1A5,
             3 => FrsRequiredCurrent::Current3A,
+            // Panic safety: This will never panic if the mask above does not change
+            #[allow(clippy::unreachable)]
             _ => unreachable!(),
         }
     }

--- a/src/pdo/source.rs
+++ b/src/pdo/source.rs
@@ -146,14 +146,17 @@ pub enum PeakCurrent {
     Pct150,
 }
 
-const PEAK_CURRENT_MASK: u8 = 0x3;
 impl From<u8> for PeakCurrent {
     fn from(value: u8) -> Self {
+        // NOTE: If this mask changes, the panic safety comment below must be reevaluated
+        const PEAK_CURRENT_MASK: u8 = 0x3;
         match value & PEAK_CURRENT_MASK {
             0x0 => PeakCurrent::Pct100,
             0x1 => PeakCurrent::Pct110,
             0x2 => PeakCurrent::Pct125,
             0x3 => PeakCurrent::Pct150,
+            // Panic safety: This will never panic if the mask above does not change
+            #[allow(clippy::unreachable)]
             _ => unreachable!(),
         }
     }

--- a/src/ucsi/lpm/get_cable_property.rs
+++ b/src/ucsi/lpm/get_cable_property.rs
@@ -68,6 +68,8 @@ impl From<u16> for SpeedSupported {
             0x1 => SpeedSupported::Kbps(raw.value()),
             0x2 => SpeedSupported::Mbps(raw.value()),
             0x3 => SpeedSupported::Gbps(raw.value()),
+            // Panic safety: `units` is constrained to 2 bits via bitfield so this will never panic
+            #[allow(clippy::unreachable)]
             _ => unreachable!(),
         }
     }
@@ -121,11 +123,14 @@ pub enum PlugEndType {
 
 impl From<u8> for PlugEndType {
     fn from(value: u8) -> Self {
+        // NOTE: If this mask changes, the panic safety comment below must be reevaluated
         match value & 0x3 {
             0x0 => PlugEndType::TypeA,
             0x1 => PlugEndType::TypeB,
             0x2 => PlugEndType::TypeC,
             0x3 => PlugEndType::Other,
+            // Panic safety: This will never panic if the mask above does not change
+            #[allow(clippy::unreachable)]
             _ => unreachable!(),
         }
     }

--- a/src/ucsi/lpm/get_connector_status.rs
+++ b/src/ucsi/lpm/get_connector_status.rs
@@ -704,8 +704,11 @@ impl From<ResponseData> for [u8; RESPONSE_DATA_LEN] {
             raw.set_partner_flags(status.partner_flags.into());
             raw.set_partner_type(status.partner_type as u8);
 
-            if status.rdo.is_some_and(|rdo| rdo != 0) {
-                raw.set_rdo(status.rdo.unwrap());
+            // Note: Can be collapsed to a let chain when this crate is updated to 2024 edition
+            if let Some(rdo) = status.rdo {
+                if rdo != 0 {
+                    raw.set_rdo(rdo)
+                }
             }
 
             if let Some(battery_charging_status) = status.battery_charging_status {

--- a/src/ucsi/lpm/set_power_level.rs
+++ b/src/ucsi/lpm/set_power_level.rs
@@ -136,10 +136,17 @@ impl Args {
     }
 
     pub fn type_c_current(&self) -> Current {
-        let current: Result<Current, _> = Current::try_from(self.0.type_c_current());
-        current.unwrap() // Won't panic, validated in try_from
+        // Panic Safety: ArgsRaw::type_c_current is guaranteed to be a valid and defined value of Current:
+        // 1. Args::set_type_c_current only accepts Current values
+        // 2. ArgsRaw::set_type_c_current is only set with values from u8::from(Current)
+        // 3. Current::try_from(u8) only fails for undefined values and is unit tested with all defined values to roundtrip correctly
+        // 4. The only way to construct an Args is through Args::try_from([u8; COMMAND_DATA_LEN]), which validates Current::try_from(u8)
+        #[allow(clippy::unwrap_used)]
+        Current::try_from(self.0.type_c_current()).unwrap()
     }
 
+    // NOTE: Self::type_c_current has a SAFETY requirement on argument being `Current` and only setting with values
+    // returned from `impl From<Current> for u8`
     pub fn set_type_c_current(&mut self, type_c_current: Current) -> &mut Self {
         self.0.set_type_c_current(type_c_current.into());
         self

--- a/src/ucsi/mod.rs
+++ b/src/ucsi/mod.rs
@@ -286,11 +286,18 @@ impl CommandHeader {
 
     /// Returns command type
     pub fn command(&self) -> CommandType {
-        // Unwrap is safe here because we validate the command in `try_from`
+        // Panic Safety: CommandHeaderRaw::command is guaranteed to be a valid and defined value of CommandType:
+        // 1. CommandHeader::set_command only accepts CommandType values
+        // 2. CommandHeaderRaw::set_command is only set with values from u8::from(CommandType)
+        // 3. CommandType::try_from(u8) only fails for undefined values and is unit tested with all defined values to roundtrip correctly
+        // 4. The only way to construct a CommandHeader is through CommandHeader::try_from(u16), which validates CommandType::try_from(u8)
+        #[allow(clippy::unwrap_used)]
         self.0.command().try_into().unwrap()
     }
 
     /// Sets command type
+    // NOTE: Self::command has a SAFETY requirement on argument being `CommandType` and only setting with values
+    // returned from `impl From<CommandType> for u8`
     pub fn set_command(&mut self, command: CommandType) -> &mut Self {
         self.0.set_command(command as u8);
         self


### PR DESCRIPTION
This PR audits potential panics. Most were cases that are easily proven to never panic (assuming the assumptions in the code are held) and these assumptions are defined very close to the potential panic path, so I think it was safe to allow these instead of returning an error.

A refactor of the `Args` type may help eliminate the need for unwraps (see: https://github.com/OpenDevicePartnership/embedded-usb-pd/issues/61).

`Rdo::for_pdo` now returns an `Option<Self>` and is public so a minor breaking change has been introduced.

Resolves #59 