### PR TITLE
Add RUSTSEC-2026-0173 exception

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,20 +3,6 @@
 version = 4
 
 [[package]]
-name = "aquamarine"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f50776554130342de4836ba542aa85a4ddb361690d7e8df13774d7284c3d5c2"
-dependencies = [
- "include_dir",
- "itertools",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,12 +79,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
 name = "embedded-hal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,39 +97,10 @@ dependencies = [
 name = "embedded-usb-pd"
 version = "0.1.0"
 dependencies = [
- "aquamarine",
  "bincode",
  "bitfield",
  "defmt 0.3.100",
  "embedded-hal-async",
-]
-
-[[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ defmt = { version = "0.3", optional = true }
 embedded-hal-async = "1.0.0"
 bitfield = "0.19.0"
 bincode = { version = "2.0.1", default-features = false }
-aquamarine = "0.6.0"
 
 [features]
 default = []

--- a/deny.toml
+++ b/deny.toml
@@ -76,6 +76,7 @@ ignore = [
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
     { id = "RUSTSEC-2024-0370", reason = "proc-macro-error is unmaintained, no safe upgrade available, need upstream dependencies to migrate away from it." },
     { id = "RUSTSEC-2025-0141", reason = "bincode is unmaintained, planning on migrating to an alternative." },
+    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is unmaintained, no safe upgrade available, need upstream dependencies to migrate away from it." },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/src/ucsi/ppm/state_machine.rs
+++ b/src/ucsi/ppm/state_machine.rs
@@ -71,7 +71,7 @@ pub struct InvalidTransition<'a, T: PortId> {
     pub input: Input<'a, T>,
 }
 
-// Doctest tries to compile the mermaid code as rust so just disable it
+/// PPM State Machine
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct StateMachine<T: PortId> {

--- a/src/ucsi/ppm/state_machine.rs
+++ b/src/ucsi/ppm/state_machine.rs
@@ -72,8 +72,6 @@ pub struct InvalidTransition<'a, T: PortId> {
 }
 
 // Doctest tries to compile the mermaid code as rust so just disable it
-#[cfg_attr(not(doctest), aquamarine::aquamarine)]
-#[cfg_attr(not(doctest), doc = "include_mmd!(\"docs/ucsi/ppm_state_machine.mmd\")")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct StateMachine<T: PortId> {


### PR DESCRIPTION
`aquamarine` depends on `proc-macro-error2` which is now unmaintained.
Remove it as it provides a minor QoL improvement. Mermaid diagrams are
still present in the docs directory and Github supports rendered
previews. Add an exception since defmt also depends on this crate.