### PR TITLE
ucsi/v1_2: Fix missing validation in `get_pdos` and add more test coverage

### DIFF
--- a/src/ucsi/v1_2/lpm/get_alternate_modes.rs
+++ b/src/ucsi/v1_2/lpm/get_alternate_modes.rs
@@ -212,6 +212,31 @@ mod test {
     }
 
     #[test]
+    fn test_decode_args_invalid_recipient() {
+        // Invalid recipient (0x7), connector 3, 2 requested alt modes, mode offset 1
+        let encoded: [u8; 6] = [0x07, 0x3, 0x1, 0x2, 0x0, 0x0];
+        let Err(bincode::error::DecodeError::UnexpectedVariant {
+            type_name,
+            allowed,
+            found,
+        }): Result<(Args, usize), _> = decode_from_slice(&encoded, standard().with_fixed_int_encoding())
+        else {
+            panic!("Expected UnexpectedVariant error");
+        };
+        assert_eq!(type_name, "Recipient");
+        assert_eq!(
+            *allowed,
+            bincode::error::AllowedEnumVariants::Allowed(&[
+                Recipient::Connector as u32,
+                Recipient::Sop as u32,
+                Recipient::SopP as u32,
+                Recipient::SopPp as u32,
+            ])
+        );
+        assert_eq!(found, 0x07);
+    }
+
+    #[test]
     fn test_decode_response_data() {
         // No particular meaning to these values
         let encoded: [u8; RESPONSE_DATA_LEN] = [0x34, 0x12, 0x78, 0x56, 0x34, 0x12, 0x12, 0x34, 0x12, 0x34, 0x56, 0x78];

--- a/src/ucsi/v1_2/lpm/get_pdos.rs
+++ b/src/ucsi/v1_2/lpm/get_pdos.rs
@@ -220,7 +220,7 @@ impl<Context> Decode<Context> for Args {
         let raw = u32::decode(decoder)?;
         // Read padding
         let _padding: [u8; COMMAND_PADDING] = Decode::decode(decoder)?;
-        Ok(Self(ArgsRaw(raw)))
+        Args::try_from(raw).map_err(Into::into)
     }
 }
 
@@ -307,6 +307,30 @@ mod test {
             .set_role(PowerRole::Source)
             .set_source_capability_type(SourceCapabilityType::Maximum);
         assert_eq!(decoded, expected);
+    }
+
+    #[test]
+    fn test_decode_args_invalid_source_capability_type() {
+        // Partner, connector 3, 1 PDO, source, invalid source-capability-type (0x3), offset 4
+        let encoded: [u8; 6] = [0x83, 0x04, 0x1C, 0x00, 0x00, 0x00];
+        let Err(bincode::error::DecodeError::UnexpectedVariant {
+            type_name,
+            allowed,
+            found,
+        }): Result<(Args, usize), _> = decode_from_slice(&encoded, standard().with_fixed_int_encoding())
+        else {
+            panic!("Expected UnexpectedVariant error");
+        };
+        assert_eq!(type_name, "SourceCapabilityType");
+        assert_eq!(
+            *allowed,
+            bincode::error::AllowedEnumVariants::Allowed(&[
+                SourceCapabilityType::Current as u32,
+                SourceCapabilityType::Advertised as u32,
+                SourceCapabilityType::Maximum as u32,
+            ])
+        );
+        assert_eq!(found, 0x03);
     }
 
     #[test]

--- a/src/ucsi/v1_2/lpm/set_power_level.rs
+++ b/src/ucsi/v1_2/lpm/set_power_level.rs
@@ -248,4 +248,21 @@ mod test {
             .set_power_args(false, 60, 1000);
         assert_eq!(decoded, expected);
     }
+
+    #[test]
+    fn test_decode_args_invalid_current() {
+        // Connector 0, invalid type_c_current value (0x4) at bits 18:16
+        let encoded: [u8; COMMAND_DATA_LEN] = [0x00, 0x00, 0x04, 0x00, 0x00, 0x00];
+        let Err(bincode::error::DecodeError::UnexpectedVariant {
+            type_name,
+            allowed,
+            found,
+        }): Result<(Args, usize), _> = decode_from_slice(&encoded, standard().with_fixed_int_encoding())
+        else {
+            panic!("Expected UnexpectedVariant error");
+        };
+        assert_eq!(type_name, "Current");
+        assert_eq!(*allowed, bincode::error::AllowedEnumVariants::Range { min: 0, max: 3 });
+        assert_eq!(found, 0x04);
+    }
 }


### PR DESCRIPTION
Fix missing validation in `get_pdos` that could result in a panic, add more
test coverage to catch this.

Assisted-by: GitHub Copilot:claude-opus-4.7